### PR TITLE
fix verifying signatures and decryption

### DIFF
--- a/lib/xml_sec.rb
+++ b/lib/xml_sec.rb
@@ -70,16 +70,16 @@ module XMLSecurity
 
     def validate_doc(base64_cert, logger)
       # validate references
-      sig_element = find_first("//ds:Signature", { "ds" => "http://www.w3.org/2000/09/xmldsig#" })
+      sig_element = find_first("//ds:Signature", Onelogin::NAMESPACES)
 
       c14n_method = nil
-      c14n_method_element = sig_element.find_first(".//ds:CanonicalizationMethod", { "ds" => "http://www.w3.org/2000/09/xmldsig#" })
+      c14n_method_element = sig_element.find_first(".//ds:CanonicalizationMethod", Onelogin::NAMESPACES)
       if c14n_method_element
         c14n_method = c14n_method_element["Algorithm"]
       end
 
       # check digests
-      sig_element.find(".//ds:Reference", { "ds" => "http://www.w3.org/2000/09/xmldsig#" }).each do |ref|
+      sig_element.find(".//ds:Reference", Onelogin::NAMESPACES).each do |ref|
         # Find the referenced element
         uri = ref["URI"]
         ref_element = find_first("//*[@ID='#{uri[1,uri.size]}']")
@@ -89,13 +89,13 @@ module XMLSecurity
         ref_document.root = ref_document.import(ref_element)
 
         # Remove the Signature node
-        ref_document_sig_element = ref_document.find_first(".//ds:Signature", { "ds" => "http://www.w3.org/2000/09/xmldsig#" })
+        ref_document_sig_element = ref_document.find_first(".//ds:Signature", Onelogin::NAMESPACES)
         ref_document_sig_element.remove! if ref_document_sig_element
 
         # Canonicalize the referenced element's document
         ref_document_canonicalized = canonicalize_doc(ref_document, c14n_method)
         hash = Base64::encode64(Digest::SHA1.digest(ref_document_canonicalized)).chomp
-        digest_value = sig_element.find_first(".//ds:DigestValue", { "ds" => "http://www.w3.org/2000/09/xmldsig#" }).content
+        digest_value = sig_element.find_first(".//ds:DigestValue", Onelogin::NAMESPACES).content
 
         if hash != digest_value
           @validation_error = <<-EOF.gsub(/^\s+/, '')
@@ -114,10 +114,10 @@ module XMLSecurity
       end
  
       # verify signature
-      signed_info_element = sig_element.find_first(".//ds:SignedInfo", { "ds" => "http://www.w3.org/2000/09/xmldsig#" })
+      signed_info_element = sig_element.find_first(".//ds:SignedInfo", Onelogin::NAMESPACES)
       canon_string = canonicalize_node(signed_info_element, c14n_method)
 
-      base64_signature = sig_element.find_first(".//ds:SignatureValue", { "ds" => "http://www.w3.org/2000/09/xmldsig#" }).content
+      base64_signature = sig_element.find_first(".//ds:SignatureValue", Onelogin::NAMESPACES).content
       signature = Base64.decode64(base64_signature)
 
       cert_text = Base64.decode64(base64_cert)


### PR DESCRIPTION
Before we were erroring out if we couldn't find a Signature in a Response,
however, the signature might be inside the encrypted portion. Now we will
check for a signature before decryption, then again after decrypting (if we
didn't find on the first time). We only fail if no signatures are found at
all.

This is another band-aid around the fact that we're not using a real xmlsec
library.
