### PR TITLE
support endpoint URLs with query parameters

### DIFF
--- a/lib/onelogin/saml/auth_request.rb
+++ b/lib/onelogin/saml/auth_request.rb
@@ -33,7 +33,7 @@ module Onelogin::Saml
       base64_request    = Base64.encode64(deflated_request)  
       encoded_request   = CGI.escape(base64_request)
 
-      @forward_url = @settings.idp_sso_target_url + "?SAMLRequest=" + encoded_request
+      @forward_url = @settings.idp_sso_target_url + (@settings.idp_sso_target_url.include?("?") ? "&" : "?") + "SAMLRequest=" + encoded_request
     end
     
     private 

--- a/lib/onelogin/saml/log_out_request.rb
+++ b/lib/onelogin/saml/log_out_request.rb
@@ -26,7 +26,7 @@ module Onelogin::Saml
       base64_logout_request = Base64.encode64(deflated_logout_request)  
       encoded_logout_request = CGI.escape(base64_logout_request)  
 
-      @forward_url = @settings.idp_slo_target_url + "?SAMLRequest=" + encoded_logout_request 
+      @forward_url = @settings.idp_slo_target_url + (@settings.idp_slo_target_url.include?("?") ? "&" : "?") + "SAMLRequest=" + encoded_logout_request 
   
       @forward_url
     end


### PR DESCRIPTION
e.g.,
  http://foo => http://foo?SAMLRequest=...
  http://foo?bar => http://foo?bar&SAMLRequest=...
