### PR TITLE
Fix LogOutRequest XML signatures

### DIFF
--- a/spec/log_out_request_spec.rb
+++ b/spec/log_out_request_spec.rb
@@ -8,6 +8,33 @@ def verify_query_string_signature(settings, forward_url)
   cert.public_key.verify(OpenSSL::Digest::SHA1.new, Base64.decode64(CGI.unescape(signature)), signed_data)
 end
 
+def verify_xml_signature(settings, forward_url)
+  forward_url = URI.parse(forward_url)
+  cgi_encoded_logout_request = forward_url.query.split('&').first.split('=').last
+  base64_logout_request      = CGI.unescape(cgi_encoded_logout_request)
+  deflated_logout_request    = Base64.decode64(base64_logout_request)
+  logout_request             = inflate(deflated_logout_request)
+
+  log_out_xml = LibXML::XML::Document.string(logout_request)
+  log_out_xml.extend(XMLSecurity::SignedDocument)
+
+  result = log_out_xml.validate(settings.idp_cert_fingerprint, nil)
+  if result
+    result
+  else
+    log_out_xml.validation_error
+  end
+end
+
+# see http://stackoverflow.com/questions/1361892/how-to-decompress-gzip-string-in-ruby
+def inflate(string)
+  zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+  buf = zstream.inflate(string)
+  zstream.finish
+  zstream.close
+  buf
+end
+
 describe Onelogin::Saml::LogOutRequest do
   it "includes destination in the saml:LogoutRequest attributes" do
     settings = Onelogin::Saml::Settings.new(
@@ -24,12 +51,40 @@ describe Onelogin::Saml::LogOutRequest do
     log_out_xml.find_first('/samlp:LogoutRequest', Onelogin::NAMESPACES).attributes['Destination'].should ==  "http://idp.example.com/saml2"
   end
 
+  it "properly sets the Format attribute NameID based on settings" do
+    settings = Onelogin::Saml::Settings.new(
+      :idp_slo_target_url => "http://idp.example.com/saml2",
+      :name_identifier_format => Onelogin::Saml::NameIdentifiers::UNSPECIFIED
+    )
+    session = {}
+    log_out_request = Onelogin::Saml::LogOutRequest.new(settings, session)
+    log_out_request.generate_request
+
+    log_out_xml = LibXML::XML::Document.string(log_out_request.request_xml)
+    log_out_xml.find_first('/samlp:LogoutRequest/saml:NameID', Onelogin::NAMESPACES).attributes['Format'].should == Onelogin::Saml::NameIdentifiers::UNSPECIFIED
+  end
+
   it "can sign the generated request XML" do
     settings = Onelogin::Saml::Settings.new(
       :xmlsec_certificate => fixture_path("test1-cert.pem"),
       :xmlsec_privatekey => fixture_path("test1-key.pem"),
       :idp_slo_target_url => "http://idp.example.com/saml2",
-      :idp_cert_fingerprint => 'def18dbed547cdf3d52b627f41637c443045fe33'
+      :idp_cert_fingerprint => 'c38e789fcfbbd4727bd8ff7fc365b44fc3596bda'
+    )
+    session = {}
+
+    log_out_request = Onelogin::Saml::LogOutRequest.new(settings, session)
+    forward_url = log_out_request.generate_request
+
+    verify_xml_signature(settings, forward_url).should == true
+  end
+
+  it "includes the certificate in the <KeyInfo> of the signature" do
+    settings = Onelogin::Saml::Settings.new(
+      :xmlsec_certificate => fixture_path("test1-cert.pem"),
+      :xmlsec_privatekey => fixture_path("test1-key.pem"),
+      :idp_slo_target_url => "http://idp.example.com/saml2",
+      :idp_cert_fingerprint => 'c38e789fcfbbd4727bd8ff7fc365b44fc3596bda'
     )
     session = {}
 
@@ -37,7 +92,12 @@ describe Onelogin::Saml::LogOutRequest do
     log_out_request.generate_request
 
     log_out_xml = LibXML::XML::Document.string(log_out_request.request_xml)
-    log_out_xml.find_first('/samlp:LogoutRequest/ds:Signature/ds:SignatureValue', Onelogin::NAMESPACES).should_not be_nil
+
+    base64_cert_der = Base64.encode64(OpenSSL::X509::Certificate.new(File.read(settings.xmlsec_certificate)).to_der).chomp
+
+    x509_certificate_node = log_out_xml.find_first('/samlp:LogoutRequest/ds:Signature/ds:KeyInfo/ds:X509Data/ds:X509Certificate', Onelogin::NAMESPACES)
+    x509_certificate_node.should be_instance_of LibXML::XML::Node
+    x509_certificate_node.content.gsub("\n", '').should == base64_cert_der.gsub("\n", '')
   end
 
   it "can sign the generated query string" do


### PR DESCRIPTION
- The XMLSecurity.sign method was outputting its result with pretty
  formatting turned on. This was messing with whitespace in the result
  rendering the included digest (and therefore signature) invalid
  - When sigining the XML, optionally add a URI to the Reference which
    points to the ID of the element being signed, and use this feature in
    when signing the LogOutRequest. Shibboleth will fail to validate
    unless this URI attribute is present and properly dereferences to the
    element being signed
  - Report the NameID format properly in the LogOutRequest; it was pinned
    as 'transient' before. This preventied Shibboleth from logging a
    user out when other NameID formats were used, causing it to respond
    with status:UnknownPrincipal
  - We now include the public certificate in the body of the
    LogOutRequest. While I have yet to find an IdP that requires it, it's
    definitely more convenient and often simplifies debugging
