### PR TITLE
remove signature element for a log out request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org/'
 
 gemspec
 

--- a/lib/onelogin/saml/log_out_request.rb
+++ b/lib/onelogin/saml/log_out_request.rb
@@ -11,11 +11,11 @@ module Onelogin::Saml
       ar = LogOutRequest.new(settings, session)
       ar.generate_request
     end
-    
+
     def generate_request
       @id = Onelogin::Saml::AuthRequest.generate_unique_id(42)
       issue_instant = Onelogin::Saml::AuthRequest.get_timestamp
-      
+
       @request_xml = <<-REQUEST_XML
 <samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="#{@id}" Version="2.0" IssueInstant="#{issue_instant}" Destination="#{@settings.idp_slo_target_url}">
   <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">#{@settings.issuer}</saml:Issuer>
@@ -23,10 +23,6 @@ module Onelogin::Saml
   <samlp:SessionIndex xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">#{@session[:session_index]}</samlp:SessionIndex>
 </samlp:LogoutRequest>
       REQUEST_XML
-
-      if settings.sign?
-        @request_xml = XMLSecurity.sign(@id, @request_xml, @settings.xmlsec_privatekey, @settings.xmlsec_certificate)
-      end
 
       deflated_logout_request = Zlib::Deflate.deflate(@request_xml, 9)[2..-5]
       base64_logout_request = Base64.encode64(deflated_logout_request)
@@ -41,7 +37,7 @@ module Onelogin::Saml
       end
 
       @forward_url = [url, query_string].join("?")
-  
+
       @forward_url
     end
 

--- a/spec/logout_response_spec.rb
+++ b/spec/logout_response_spec.rb
@@ -1,6 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper.rb')
 
-require 'ruby-debug'
 require 'rexml/document'
 require 'cgi'
 

--- a/spec/meta_data_spec.rb
+++ b/spec/meta_data_spec.rb
@@ -1,6 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper.rb')
 
-require 'ruby-debug'
 require 'rexml/document'
 
 describe Onelogin::Saml::MetaData do

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -1,6 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper.rb')
 
-require 'ruby-debug'
 require 'rexml/document'
 require 'cgi'
 
@@ -14,7 +13,7 @@ describe Onelogin::Saml::Response do
         :idp_cert_fingerprint => 'def18dbed547cdf3d52b627f41637c443045fe33'
       )
     end
-    
+
     it "should find the right attributes from an encrypted assertion" do
       @response = Onelogin::Saml::Response.new(@xmlb64, @settings)
       @response.should be_is_valid
@@ -26,7 +25,7 @@ describe Onelogin::Saml::Response do
       @response.status_code.should == "urn:oasis:names:tc:SAML:2.0:status:Success"
       @response.status_message.strip.should == ""
     end
-    
+
     it "should not be able to decrypt without the proper key" do
       @settings.xmlsec_privatekey = fixture_path("wrong-key.pem")
       XMLSecurity.mute do
@@ -52,7 +51,7 @@ describe Onelogin::Saml::Response do
       @response.status_message.strip.should == ""
     end
   end
-  
+
   it "should use namespaces correctly to look up attributes" do
     @xmlb64 = Base64.encode64(File.read(fixture_path("test2-response.xml")))
     @settings = Onelogin::Saml::Settings.new(:idp_cert_fingerprint => 'def18dbed547cdf3d52b627f41637c443045fe33')
@@ -85,7 +84,7 @@ describe Onelogin::Saml::Response do
 
   it "should not throw an exception when an empty string is passed as the doc" do
     settings = Onelogin::Saml::Settings.new
-    lambda { 
+    lambda {
       r = Onelogin::Saml::Response.new('foo', settings)
       r.should_not be_is_valid
     }.should_not raise_error


### PR DESCRIPTION
SAML 2.0 spec requires the signature element be removed from
the request body.  This commit removes the signature in the body.

See lines 578-579 in http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf

Also update the gemfile and removed trailing white spaces.
