### PR TITLE
add vagrant box for running tests in ubuntu 12.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 pkg
+.vagrant

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,11 @@ Spec::Rake::SpecTask.new('spec') do |t|
 end
 
 task :default => :spec
+
+namespace :vagrant do
+  desc 'run tests in an ubuntu 12.04 vagrant vm'
+  task :spec do
+    sh 'vagrant ssh -c "cd /vagrant; bundle check || bundle install"'
+    sh 'vagrant ssh -c "cd /vagrant; bundle exec rake spec"'
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = 'hashicorp/precise64'
+  config.vm.provision :ventriloquist do |env|
+    env.platforms << %w( ruby-1.9.3 )
+    env.packages << %w(
+      xmlsec1
+      libxmlsec1
+      libxmlsec1-dev
+    )
+  end
+end


### PR DESCRIPTION
helps test against older version of xmlsec distributed with ubuntu

requires ventriloquist vagrant plugin: https://github.com/fgrehm/ventriloquist/