### PR TITLE
revert auth_request to before 0.2.0

### DIFF
--- a/lib/onelogin/saml/auth_request.rb
+++ b/lib/onelogin/saml/auth_request.rb
@@ -1,47 +1,53 @@
-module Onelogin::Saml
-  class AuthRequest < BaseAssertion
-    attr_accessor :requested_authn_context,
-                  :assertion_consumer_service_url,
-                  :name_identifier_format
-
-    def self.parse(raw_assertion, settings = nil)
-      raise NotImplementedError
+ module Onelogin::Saml
+  class AuthRequest
+    
+    attr_reader :settings, :id, :request_xml, :forward_url
+    
+    def initialize(settings)
+      @settings = settings
     end
-
-    def self.generate(settings)
-      super(settings, {
-        destination: settings.idp_sso_target_url,
-        requested_authn_context: settings.requested_authn_context,
-        assertion_consumer_service_url: Array(settings.assertion_consumer_service_url).first,
-        name_identifier_format: settings.name_identifier_format
-      })
+    
+    def self.create(settings)
+      ar = AuthRequest.new(settings)
+      ar.generate_request
     end
+    
+    def generate_request
+      @id = Onelogin::Saml::AuthRequest.generate_unique_id(42)
+      issue_instant = Onelogin::Saml::AuthRequest.get_timestamp
 
-    def generate
-      if self.requested_authn_context
-        xml = <<-XML
-          <samlp:RequestedAuthnContext Comparison="exact">
-            <saml:AuthnContextClassRef>#{self.requested_authn_context}</saml:AuthnContextClassRef>
-          </samlp:RequestedAuthnContext>
-        XML
+      @request_xml = 
+        "<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" ID=\"#{@id}\" Version=\"2.0\" IssueInstant=\"#{issue_instant}\" ProtocolBinding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" AssertionConsumerServiceURL=\"#{Array(settings.assertion_consumer_service_url).first}\">" +
+        "<saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">#{@settings.issuer}</saml:Issuer>\n" +
+        "<samlp:NameIDPolicy xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Format=\"#{@settings.name_identifier_format}\" AllowCreate=\"true\"></samlp:NameIDPolicy>\n"
+      
+      if @settings.requested_authn_context
+        @request_xml += "<samlp:RequestedAuthnContext xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Comparison=\"exact\">"
+        @request_xml += "<saml:AuthnContextClassRef xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">#{@settings.requested_authn_context}</saml:AuthnContextClassRef>"
+        @request_xml += "</samlp:RequestedAuthnContext>\n"
       end
+        
+      @request_xml += "</samlp:AuthnRequest>"
 
-      <<-XML
-        <samlp:AuthnRequest
-          xmlns:samlp="#{Onelogin::NAMESPACES['samlp']}"
-          xmlns:saml="#{Onelogin::NAMESPACES['saml']}"
-          ID="#{self.id}"
-          Version="2.0"
-          ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-          AssertionConsumerServiceURL=\"#{self.assertion_consumer_service_url}\"
-          IssueInstant="#{self.issue_instant}">
+      deflated_request  = Zlib::Deflate.deflate(@request_xml, 9)[2..-5]     
+      base64_request    = Base64.strict_encode64(deflated_request)
+      encoded_request   = CGI.escape(base64_request)
 
-          <saml:Issuer>#{self.issuer}</saml:Issuer>
-          <samlp:NameIDPolicy Format="#{self.name_identifier_format}" AllowCreate="true"></samlp:NameIDPolicy>
-
-          #{xml}
-        </samlp:AuthnRequest>
-      XML
+      @forward_url = @settings.idp_sso_target_url + (@settings.idp_sso_target_url.include?("?") ? "&" : "?") + "SAMLRequest=" + encoded_request
+    end
+    
+    private 
+    
+    def self.generate_unique_id(length)
+      chars = ("a".."f").to_a + ("0".."9").to_a
+      chars_len = chars.size
+      unique_id = ("a".."f").to_a[rand(6)]
+      2.upto(length) { |i| unique_id << chars[rand(chars_len)] }
+      unique_id
+    end
+    
+    def self.get_timestamp
+      Time.new.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
     end
   end
 end

--- a/ruby-saml-mod.gemspec
+++ b/ruby-saml-mod.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{ruby-saml-mod}
-  s.version = "0.2.0"
+  s.version = "0.2.1"
   s.authors = ["OneLogin LLC", "Bracken", "Zach", "Cody", "Jeremy", "Paul", "Nick"]
   s.summary = %q{Ruby library for SAML service providers}
   s.homepage = %q{http://github.com/instructure/ruby-saml}

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -164,9 +164,9 @@ describe Onelogin::Saml::Response do
         :idp_slo_target_url => "http://example.com/logout.php"
       )
 
-      request = Onelogin::Saml::AuthRequest::generate(settings)
+      forward_url = Onelogin::Saml::AuthRequest::create(settings)
       prefix = "http://example.com/login.php?SAMLRequest="
-      expect(request.forward_url[0...prefix.size]).to eql(prefix)
+      expect(forward_url[0...prefix.size]).to eql(prefix)
 
       request = Onelogin::Saml::LogoutRequest::generate(name_qualifier, name_id, session_index, settings)
       prefix = "http://example.com/logout.php?SAMLRequest="
@@ -181,9 +181,9 @@ describe Onelogin::Saml::Response do
         :idp_slo_target_url => "http://example.com/logout.php?param=foo"
       )
 
-      request = Onelogin::Saml::AuthRequest::generate(settings)
+      forward_url = Onelogin::Saml::AuthRequest::create(settings)
       prefix = "http://example.com/login.php?param=foo&SAMLRequest="
-      expect(request.forward_url[0...prefix.size]).to eql(prefix)
+      expect(forward_url[0...prefix.size]).to eql(prefix)
 
       request = Onelogin::Saml::LogoutRequest::generate(name_qualifier, name_id, session_index, settings)
       prefix = "http://example.com/logout.php?param=foo&SAMLRequest="


### PR DESCRIPTION
Will bring back the changes in the next version.  Using the
base_assertion class will start signing the auth_requests when they are
generated and with such a big change to the gem we want to limit it to
only slo.  This will simplify the change and reduce the risk of breaking
other things.
